### PR TITLE
Add book selection menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # bookbot
 
 BookBot is my first [Boot.dev](https://www.boot.dev) project!
+
+## Usage
+
+Place your `.txt` books in the `books/` directory. Run the program
+with `python3 main.py` and select a book from the menu, or pass a path
+to a book file as a command line argument.

--- a/main.py
+++ b/main.py
@@ -1,19 +1,46 @@
-from stats import *
 import sys
+import os
+from stats import *
 
 # function to open (read) the book using a filepath
 def get_book_text(book_path):
     with open(book_path) as f:
         return f.read()
 
-# main to return called functions
-def main():
-    
-    if len(sys.argv) != 2:
-        print("Usage: python3 main.py <path_to_book>")
+# function to list available books and let the user select one
+def choose_book():
+    books_dir = "books"
+    if not os.path.isdir(books_dir):
+        print(f"Directory '{books_dir}' not found.")
         sys.exit(1)
 
-    book_path = sys.argv[1]
+    books = [f for f in os.listdir(books_dir) if f.endswith(".txt")]
+
+    if len(books) == 0:
+        print(f"No books found in '{books_dir}' directory.")
+        sys.exit(1)
+
+    print("Available books:")
+    for idx, book in enumerate(books, start=1):
+        print(f" {idx}. {book}")
+
+    while True:
+        choice = input("Select a book by number: ")
+        try:
+            index = int(choice) - 1
+            if 0 <= index < len(books):
+                return os.path.join(books_dir, books[index])
+        except ValueError:
+            pass
+        print("Invalid selection. Try again.")
+
+# main to return called functions
+def main():
+
+    if len(sys.argv) == 2:
+        book_path = sys.argv[1]
+    else:
+        book_path = choose_book()
         
     book_content = get_book_text(book_path)
     # Get the word count


### PR DESCRIPTION
## Summary
- show available `.txt` files in `books/` directory and prompt for a choice
- allow optional command line argument to specify a book directly
- document how to run the program

## Testing
- `python3 -m py_compile main.py stats.py`
- `python3 main.py <<'EOF'
1
EOF`

------
https://chatgpt.com/codex/tasks/task_e_687d86fa62d08328bb011a6b1a562059